### PR TITLE
Lint the documentation for Writers' Toolkit style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,44 @@
-# Auto Grafana issue triager with Gemini and OpenAI (fine tuned models)
+# Automatically triage Grafana issues with Gemini and OpenAI (fine tuned models)
 
-This is tool to automatically triage Grafana issues using OpenAI GPT or Google Gemini.
+`auto-triager` automatically triages Grafana issues using OpenAI GPT or Google Gemini.
 
-The categorizer model is used to determine the area and type of an issue.
+It uses the categorizer model to determine the area and type of an issue.
 
-## Github action integration
+## GitHub action integration
 
-The tool can be integrated with Github actions to automatically triage issues.
+You can use the tool with GitHub Actions to automatically triage issues.
 
-See [githug actions integration](./docs/github-action.md)
+For more information, refer to [GitHub Action integration](./docs/github-action.md)
 
-## How to use the OpenAI fine tuned models
+## Use the OpenAI fine tuned models
+
+To use the OpenAI fine-tuned models,
 
 ### Requirements
 
 - Go 1.22.3 or higher installed
 - [Mage](https://magefile.org/)
-- A Github personal access token with read access to public repos in the `GH_TOKEN` env var [1]
-- A fine-tuned model. See [openai-finetune.md](./docs/openai-finetune.md)
+- The `GH_TOKEN` environment variable set to a GitHub personal access token with at least read access to public repositories.
 
-### Running the triager
+  If you want the tool to also update the issue with the generated labels you can pass the `-addLabels=true` flag.
+  To update issues with labels, your token must also have the permissions to add labels to issues.
+
+- A fine-tuned model. For more information, refer to [Generate the datasets for the fine-tuned models](./docs/openai-finetune.md).
+
+### Run `auto-triager`
+
+To run `auto-triager`, use the following command:
 
 ```bash
-mage -v run:triagerFineTuned [issueId]
+mage -v run:triagerFineTuned <ISSUE ID>
 ```
 
-[1] If you wish the tool to also update the issue with the generated labels you can pass the `-addLabels=true` flag.
-Your token must have the necessary permissions to add labels to issues.
-
-Where `[issueId]` is the issue id you want to triage (without the brackets).
+Where _`ISSUE ID`_ is the issue ID you want to triage.
 
 ## How to use the Gemini with RAG implementation
 
 > [!IMPORTANT]
-> You must have the vector database generated before you can use the gemini with RAG implementation.
+> You must have the vector database generated before you can use the Gemini with RAG implementation.
 > See the relevant section on how to generate it.
 > Or you can ask a colleague to provide you with a pre-built vector db.
 
@@ -41,43 +46,50 @@ Where `[issueId]` is the issue id you want to triage (without the brackets).
 
 - Go 1.22.3 or higher installed
 - [Mage](https://magefile.org/)
-- A Github personal access token with read access to public repos in the `GH_TOKEN` env var
-- A Google Cloud Platform API key with the text embedding api enabled in the `GEMINI_API_KEY` env var
-- A generated vector database with github issues. see [gemini-with-rag.md](./docs/gemini-with-rag.md)
+- The `GH_TOKEN` environment variable set to a GitHub personal access token with at least read access to public repositories.
 
-### Running the triager
+  If you want the tool to also update the issue with the generated labels you can pass the `-addLabels=true` flag.
+  To update issues with labels, your token must also have the permissions to add labels to issues.
+
+- The `GEMINI_API_KEY` environment variable set to a Google Cloud Platform API key with the text embedding API enabled.
+- A vector database populated with GitHub issues.
+  To populate the database, refer to [Populate the vector database](./docs/gemini-rag.md)
+
+### Run `auto-triager`
+
+To run `auto-triager`, use the following command:
 
 ```bash
-mage -v run:triager [issueId]
+mage -v run:triagerFineTuned <ISSUE ID>
 ```
 
-Where `[issueId]` is the issue id you want to triage (without the brackets).
+Where _`ISSUE ID`_ is the issue ID you want to triage.
 
-This will also update the vector database in case you have new issues in the sqlitedb.
+This also updates the vector database in case you have new issues in the SQLite database.
 
 ## How does it work?
 
-There are two different implementations of the auto triager, one using Gemini with RAG and one using OpenAI fine tuned models. In practice the OpenAI doesn't need to be fine tuned but it works better.
+There are two different implementations of the auto-triager, one using Gemini with RAG, and one using OpenAI fine-tuned models.
+The OpenAI implementation doesn't have to be fine tuned but it works better if it is.
 
 ### Gemini with RAG
 
-The auto-triager uses retrieval-augmented generation (RAG) to generate a long list of historic data
-that is later sent to the remote model for analysis.
+`auto-triager` uses retrieval-augmented generation (RAG) to generate a long list of historic data that's later sent to the remote model for analysis.
 
 These are the steps that follows:
 
-- Reads the issue from Github
-- Converts the issue title/content to an embedded document via [google text embedding api](https://ai.google.dev/gemini-api/docs/embeddings)
-- Queries a pre-built vector database with all the historic issues from Grafana github
-- Puts together a prompt using the historic data, the issue content and the possible labels asking the model to classify the issue
-- Sends the prompt to the model
-- Returns the model's classification JSON output
+1. Read the issue from GitHub.
+1. Convert the issue title and content to an embedded document using the [Google text embedding API](https://ai.google.dev/gemini-api/docs/embeddings).
+1. Query a pre-built vector database with all the historic issues from Grafana GitHub.
+1. Create a prompt using the historic data, the issue content, and the possible labels asking the model to classify the issue.
+1. Send the prompt to the model.
+1. Return the model's classification JSON output.
 
-### OpenAI fine tuned models
+### OpenAI fine-tuned models
 
-The auto-triager has a command to generate a dataset that can later be used to fine tune a model via the UI https://platform.openai.com/finetune/
+`auto-triager` has a command to generate a dataset that you can use later to fine tune a model in the [UI](https://platform.openai.com/finetune/).
 
-Two datasets can be generated:
+You can generate two datasets:
 
 - A dataset for the qualitizer model.
 - A dataset for the categorizer model.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,20 +1,24 @@
-# Github action integration
+# GitHub Action integration
 
 > [!NOTE]
-> Currently the github action is using OpenAI fine-tuned models.
-> If you want to use the gemini with RAG implementation you must change the [action.yml](../action.yml) file.
+> The GitHub action uses OpenAI fine-tuned models.
+> If you want to use the Gemini with RAG implementation you must change the [action.yml](../action.yml) file.
 
 ## Requirements
 
-- A fine-tuned model (or use the default model hardcoded in the code)
-- An openai api key with access to the fine-tuned model
+- A GitHub token with permissions to read and write issue metadata.
+- A fine-tuned model (or use the default model set in the code)
+- An OpenAI API key with access to the fine-tuned model
 
 ## Usage
 
-To use the action you need to create a workflow file in your repo.
+To use the action you need to create a workflow file in your repository.
 
-The following working example will attempt to triage issues without the `internal` label and instruct
-the action to auto label with the found labels.
+The following working example triages any issues that don't have the `internal` label and adds the area and type labels to the issue.
+To use the example, you must first create the following repository secrets:
+
+- `GITHUB_TOKEN`: A token permissions to read and write issue metadata.
+- `OPENAI_API_KEY`: An OpenAI API key with access to the fine-tuned model.
 
 ```yaml
 on:
@@ -26,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@v4
 
       - name: Use Check Issue Label action
         id: check_internal
@@ -38,8 +42,4 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-## What is it doing?
-
-The code for the action is available in the [action.yml](../action.yml) file.
-
-Interally it simply calls the auto-triager (fine tuned) tool with the passed issue id and instructs it to add the labels to the issue.
+The code for action is available in the [action.yml](../action.yml) file.

--- a/docs/openai-finetune.md
+++ b/docs/openai-finetune.md
@@ -1,55 +1,58 @@
-# Generating the datasets for the fine tuned models
+# Generate the datasets for the fine-tuned models
 
-> [!NOTE]
-> You don't need to do this if you want to use the gemini with RAG implementation.
-> or use the existing fine-tuned models.
+If you want to use `auto-triager` with the OpenAI implementation, you may want to fine tune your model.
 
-If you want to generate new datasets to finetune the models again you can follow the steps below.
+If you want to use `auto-triager` with the Gemini with Rag implementation, you don't need to follow these steps.
 
-We already have fine-tuned models that are part of the grafana openai organization and you can use them directly.
+We already have fine-tuned models that are part of the Grafana OpenAI organization and you can use them directly.
+To use the existing fine-tuned models, use an API key for the **Grafanalabs experiments exploration** organization.
 
-Make sure you are using an API key for the "Grafanalabs experiments exploration" organization.
-
-To generate the datasets you need to run the fine-tuner generator tool. It is easiest to run it with the `mage` tool.
+To generate new datasets to fine tune the models again, follow this guide.
 
 ## Requirements
 
 - Go 1.22.3 or higher installed
 - [Mage](https://magefile.org/)
-- A Github personal access token with read access to public repos in the `GH_TOKEN` env var
+- The `GH_TOKEN` environment variable set to a GitHub personal access token with at least read access to public repositories.
+
+  If you want the tool to also update the issue with the generated labels you can pass the `-addLabels=true` option.
+  To update issues with labels, your token must also have the permissions to add labels to issues.
+
+  To create the token, refer to [Create a GitHub personal access token](#create-a-GitHub-personal-access-token).
 
 ## Prepare the data
 
-You need to modify the fixtures files to adjust the ids of the issues you want to generate the dataset for.
+You need to modify the fixtures files to adjust the IDs of the issues you want to generate the dataset for.
 
 ### Categorizer
 
-- `fixtures/categorizedIds.txt`: list of the ids of the issues that are correctly categorized. (used by the categorizer model)
-- `fixtures/categoryLabels.txt`: The area labels of the issues. (used by the categorizer model)
-- `fixtures/typeLabels.txt`: The type labels of the issues. (used by the categorizer model)
+- `fixtures/categorizedIds.txt`: list of the ids of the issues that are correctly categorized. Used by the categorizer model.
+- `fixtures/categoryLabels.txt`: The area labels of the issues. Used by the categorizer model.
+- `fixtures/typeLabels.txt`: The type labels of the issues. Used by the categorizer model.
 
-- [optional] `fixtures/categorizedIds.json`: Json file containing the ids, title, description and labels of the issues that are correctly categorized. Will be added on top of the `categorizedIds.txt` file.
+- `fixtures/categorizedIds.json`: (Optional) JSON file containing the IDs, title, description, and labels of correctly categorized issues. It's added on top of the `categorizedIds.txt` file.
 
 ### Qualitizer
 
-- `fixtures/good-issues-ids.txt`: The ids of the issues that are considered "good" and thus categorizable. (used by the qualitizer model)
-- `fixtures/missingInfoIds.txt`: The ids of the issues that are missing information. (used by the qualitizer model)
+- `fixtures/good-issues-ids.txt`: The IDs of the issues that are categorizable. Used by the qualitizer model.
+- `fixtures/missingInfoIds.txt`: The IDs of the issues that are missing information. Used by the qualitizer model.
 
 ## Generate the datasets
 
 For the categorizer and qualitizer models you need to run the fine-tuner generator tool.
+The following command generates the datasets in the `out` directory:
 
 ```bash
 mage -v run:finetuner categorizer
 mage -v run:finetuner qualitizer
 ```
 
-This will generate the datasets in the `out` folder.
-
 ## Fine tune the models
 
-To fine tune the models you need to go to https://platform.openai.com/finetune/ and create a new fine tune job.
+To fine tune the models you must create a new fine tune job.
 
-- Select the base model to fine tune
-- Select the dataset to use from the out folder (categorizer or qualitizer)
-- Put a name for the job: Usually auto-triager-[qualitizer|categorizer]
+1. Browse to <https://platform.openai.com/finetune/>.
+1. Create a new fine tune job.
+1. Select the base model to fine tune
+1. Select the dataset to use from the `out` directory. Use either the categorizer or qualitizer dataset.
+1. Choose a name for the job, usually `auto-triager-<qualitizer|categorizer>`


### PR DESCRIPTION
https://grafana.com/docs/writers-toolkit/

There's a lot of style changes here, too many to list. If you have any questions, I'm happy to answer them on this PR.

Some important changes:

- I've tried to refer to the tool consistently as `auto-triager` which I understand to be its name.
- I've left the `scrapper` Mage typo in, but can fix that in a follow-up PR if you'd like it.
