### PR TITLE
Chore: Adding provisioning/datasources label

### DIFF
--- a/fixtures/categoryLabels.txt
+++ b/fixtures/categoryLabels.txt
@@ -77,6 +77,7 @@ area/playlist
 area/plugins
 area/plugins-catalog
 area/provisioning
+area/provisioning/datasources
 area/public-dashboards
 area/query-library
 area/recorded-queries


### PR DESCRIPTION
I have added a new label called `area/provisioning/datasources` for issues like this: https://github.com/grafana/grafana/issues/94645

Now adding this label to the list but not sure what needs to happen after merge.

Related PR for add-to-project automation in grafana/grafana https://github.com/grafana/grafana/pull/94899