### PR TITLE
Remove `area/editor` label

### DIFF
--- a/fixtures/categoryLabels.txt
+++ b/fixtures/categoryLabels.txt
@@ -32,7 +32,6 @@ area/dashboard/tv
 area/dashboard/variable
 area/dashboards/panel
 area/data/export
-area/editor
 area/explore
 area/exploremetrics
 area/expressions


### PR DESCRIPTION
Also removing from grafana/grafana repo here:
https://github.com/grafana/grafana/pull/101682

Discussed on Slack here:
https://raintank-corp.slack.com/archives/C03E2AQKU2W/p1741259106988879?thread_ts=1741252873.131439&cid=C03E2AQKU2W and here:
https://raintank-corp.slack.com/archives/C04CHPYT954/p1741259963315269?thread_ts=1741259774.023669&cid=C04CHPYT954

We concluded that this label doesn't obviously translate to a single team, so we decided to remove it.