### PR TITLE
chore: migrate codeowners to @grafana/grafana-catalog

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
 
-* @grafana/plugins-platform-backend @grafana/plugins-platform-frontend @grafana/plugins-platform
+* @grafana/grafana-catalog


### PR DESCRIPTION
## Summary

Migrate ownership from the three retiring plugins-platform handles to a single new handle `@grafana/grafana-catalog`:

- `@grafana/plugins-platform` → `@grafana/grafana-catalog`
- `@grafana/plugins-platform-frontend` → `@grafana/grafana-catalog`
- `@grafana/plugins-platform-backend` → `@grafana/grafana-catalog`

Tracking issue: grafana/grafana-catalog-team#870

## Test plan
- [x] CI passes
- [x] CODEOWNERS validation succeeds