### PR TITLE
chore: bump categorizerModel to gpt-5.5

### DIFF
--- a/pkg/cmd/triager-openai/triager-openai.go
+++ b/pkg/cmd/triager-openai/triager-openai.go
@@ -47,7 +47,7 @@ var (
 	)
 	categorizerModel = flag.String(
 		"categorizerModel",
-		"gpt-5.2", // regular model from openai
+		"gpt-5.5", // regular model from openai
 		"Model to use",
 	)
 	addLabels = flag.Bool(


### PR DESCRIPTION
Bumps the default `categorizerModel` from gpt-5.2 to gpt-5.5.