### PR TITLE
chore(renovate): extend shared grafana-catalog-team preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,11 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-      "github>grafana/grafana-community-team//renovate/renovate"
+      "github>grafana/grafana-catalog-team//renovate/renovate"
     ],
     "ignorePresets": [
         "github>grafana/grafana-renovate-config//presets/base",
+        "github>grafana/grafana-renovate-config//presets/automerge",
         "github>grafana/grafana-renovate-config//presets/docker",
         "github>grafana/grafana-renovate-config//presets/github-actions",
         "github>grafana/grafana-renovate-config//presets/helm",


### PR DESCRIPTION
Point the Renovate config at the renamed team preset (grafana-community-team was renamed to grafana-catalog-team) so this repo keeps tracking the shared config. Also added the automerge preset to ignorePresets so the repo file carries all four team-standard disables (base, automerge, labels, npm). ignorePresets is not inherited from extended presets (renovatebot/renovate#14818), so it has to live in this file. Existing packageRules, labels, and the other ignorePresets entries are unchanged.

Part of grafana/grafana-catalog-team#1052.